### PR TITLE
Add template to use get method

### DIFF
--- a/examples/greeter.http.go
+++ b/examples/greeter.http.go
@@ -52,31 +52,32 @@ func (h *GreeterHTTPConverter) SayHello(cb func(ctx context.Context, w http.Resp
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		body, err := ioutil.ReadAll(r.Body)
-		if err != nil {
-			cb(ctx, w, r, nil, nil, err)
-			return
-		}
-
 		arg := &HelloRequest{}
-
 		contentType := r.Header.Get("Content-Type")
-		switch contentType {
-		case "application/protobuf", "application/x-protobuf":
-			if err := proto.Unmarshal(body, arg); err != nil {
+		if r.Method != http.MethodGet {
+			body, err := ioutil.ReadAll(r.Body)
+			if err != nil {
 				cb(ctx, w, r, nil, nil, err)
 				return
 			}
-		case "application/json":
-			if err := jsonpb.Unmarshal(bytes.NewBuffer(body), arg); err != nil {
+
+			switch contentType {
+			case "application/protobuf", "application/x-protobuf":
+				if err := proto.Unmarshal(body, arg); err != nil {
+					cb(ctx, w, r, nil, nil, err)
+					return
+				}
+			case "application/json":
+				if err := jsonpb.Unmarshal(bytes.NewBuffer(body), arg); err != nil {
+					cb(ctx, w, r, nil, nil, err)
+					return
+				}
+			default:
+				w.WriteHeader(http.StatusUnsupportedMediaType)
+				_, err := fmt.Fprintf(w, "Unsupported Content-Type: %s", contentType)
 				cb(ctx, w, r, nil, nil, err)
 				return
 			}
-		default:
-			w.WriteHeader(http.StatusUnsupportedMediaType)
-			_, err := fmt.Fprintf(w, "Unsupported Content-Type: %s", contentType)
-			cb(ctx, w, r, nil, nil, err)
-			return
 		}
 
 		ret, err := h.srv.SayHello(ctx, arg)
@@ -85,7 +86,16 @@ func (h *GreeterHTTPConverter) SayHello(cb func(ctx context.Context, w http.Resp
 			return
 		}
 
-		switch contentType {
+		accept := r.Header.Get("Accept")
+		if accept == "*/*" {
+			if contentType != "" {
+				accept = contentType
+			} else {
+				accept = "application/json"
+			}
+		}
+
+		switch accept {
 		case "application/protobuf", "application/x-protobuf":
 			buf, err := proto.Marshal(ret)
 			if err != nil {

--- a/examples/greeter.http.go
+++ b/examples/greeter.http.go
@@ -87,7 +87,7 @@ func (h *GreeterHTTPConverter) SayHello(cb func(ctx context.Context, w http.Resp
 		}
 
 		accept := r.Header.Get("Accept")
-		if accept == "*/*" {
+		if accept == "*/*" || accept == "" {
 			if contentType != "" {
 				accept = contentType
 			} else {

--- a/generator.go
+++ b/generator.go
@@ -181,15 +181,13 @@ func (h *{{ $service.Name }}HTTPConverter) {{ $method.Name }}(cb func(ctx contex
 
 		arg := &{{ $method.Arg }}{}
 		contentType := r.Header.Get("Content-Type")
-
-		body, err := ioutil.ReadAll(r.Body)
-		if err != nil {
-			cb(ctx, w, r, nil, nil, err)
-			return
-		}
-
-
 		if r.Method != http.MethodGet {
+			body, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				cb(ctx, w, r, nil, nil, err)
+				return
+			}
+
 			switch contentType {
 			case "application/protobuf", "application/x-protobuf":
 				if err := proto.Unmarshal(body, arg); err != nil {

--- a/generator.go
+++ b/generator.go
@@ -214,7 +214,7 @@ func (h *{{ $service.Name }}HTTPConverter) {{ $method.Name }}(cb func(ctx contex
 		}
 
 		accept := r.Header.Get("Accept")
-		if accept == "*/*" {
+		if accept == "*/*" || accept == ""{
 			if contentType != "" {
 				accept = contentType
 			} else {

--- a/generator.go
+++ b/generator.go
@@ -179,31 +179,34 @@ func (h *{{ $service.Name }}HTTPConverter) {{ $method.Name }}(cb func(ctx contex
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
+		arg := &{{ $method.Arg }}{}
+		contentType := r.Header.Get("Content-Type")
+
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
 			cb(ctx, w, r, nil, nil, err)
 			return
 		}
 
-		arg := &{{ $method.Arg }}{}
 
-		contentType := r.Header.Get("Content-Type")
-		switch contentType {
-		case "application/protobuf", "application/x-protobuf":
-			if err := proto.Unmarshal(body, arg); err != nil {
+		if r.Method != http.MethodGet {
+			switch contentType {
+			case "application/protobuf", "application/x-protobuf":
+				if err := proto.Unmarshal(body, arg); err != nil {
+					cb(ctx, w, r, nil, nil, err)
+					return
+				}
+			case "application/json":
+				if err := jsonpb.Unmarshal(bytes.NewBuffer(body), arg); err != nil {
+					cb(ctx, w, r, nil, nil, err)
+					return
+				}
+			default:
+				w.WriteHeader(http.StatusUnsupportedMediaType)
+				_, err := fmt.Fprintf(w, "Unsupported Content-Type: %s", contentType)
 				cb(ctx, w, r, nil, nil, err)
 				return
 			}
-		case "application/json":
-			if err := jsonpb.Unmarshal(bytes.NewBuffer(body), arg); err != nil {
-				cb(ctx, w, r, nil, nil, err)
-				return
-			}
-		default:
-			w.WriteHeader(http.StatusUnsupportedMediaType)
-			_, err := fmt.Fprintf(w, "Unsupported Content-Type: %s", contentType)
-			cb(ctx, w, r, nil, nil, err)
-			return
 		}
 
 		ret, err := h.srv.{{ $method.Name }}(ctx, arg)
@@ -212,7 +215,16 @@ func (h *{{ $service.Name }}HTTPConverter) {{ $method.Name }}(cb func(ctx contex
 			return
 		}
 
-		switch contentType {
+		accept := r.Header.Get("Accept")
+		if accept == "*/*" {
+			if contentType != "" {
+				accept = contentType
+			} else {
+				accept = "application/json"
+			}
+		}
+
+		switch accept {
 		case "application/protobuf", "application/x-protobuf":
 			buf, err := proto.Marshal(ret)
 			if err != nil {

--- a/testdata/auth/auth.http.go
+++ b/testdata/auth/auth.http.go
@@ -52,31 +52,32 @@ func (h *TestServiceHTTPConverter) UnaryCall(cb func(ctx context.Context, w http
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		body, err := ioutil.ReadAll(r.Body)
-		if err != nil {
-			cb(ctx, w, r, nil, nil, err)
-			return
-		}
-
 		arg := &Request{}
-
 		contentType := r.Header.Get("Content-Type")
-		switch contentType {
-		case "application/protobuf", "application/x-protobuf":
-			if err := proto.Unmarshal(body, arg); err != nil {
+		if r.Method != http.MethodGet {
+			body, err := ioutil.ReadAll(r.Body)
+			if err != nil {
 				cb(ctx, w, r, nil, nil, err)
 				return
 			}
-		case "application/json":
-			if err := jsonpb.Unmarshal(bytes.NewBuffer(body), arg); err != nil {
+
+			switch contentType {
+			case "application/protobuf", "application/x-protobuf":
+				if err := proto.Unmarshal(body, arg); err != nil {
+					cb(ctx, w, r, nil, nil, err)
+					return
+				}
+			case "application/json":
+				if err := jsonpb.Unmarshal(bytes.NewBuffer(body), arg); err != nil {
+					cb(ctx, w, r, nil, nil, err)
+					return
+				}
+			default:
+				w.WriteHeader(http.StatusUnsupportedMediaType)
+				_, err := fmt.Fprintf(w, "Unsupported Content-Type: %s", contentType)
 				cb(ctx, w, r, nil, nil, err)
 				return
 			}
-		default:
-			w.WriteHeader(http.StatusUnsupportedMediaType)
-			_, err := fmt.Fprintf(w, "Unsupported Content-Type: %s", contentType)
-			cb(ctx, w, r, nil, nil, err)
-			return
 		}
 
 		ret, err := h.srv.UnaryCall(ctx, arg)
@@ -85,7 +86,16 @@ func (h *TestServiceHTTPConverter) UnaryCall(cb func(ctx context.Context, w http
 			return
 		}
 
-		switch contentType {
+		accept := r.Header.Get("Accept")
+		if accept == "*/*" {
+			if contentType != "" {
+				accept = contentType
+			} else {
+				accept = "application/json"
+			}
+		}
+
+		switch accept {
 		case "application/protobuf", "application/x-protobuf":
 			buf, err := proto.Marshal(ret)
 			if err != nil {

--- a/testdata/helloworld/helloworld.http.go
+++ b/testdata/helloworld/helloworld.http.go
@@ -52,31 +52,32 @@ func (h *GreeterHTTPConverter) SayHello(cb func(ctx context.Context, w http.Resp
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		body, err := ioutil.ReadAll(r.Body)
-		if err != nil {
-			cb(ctx, w, r, nil, nil, err)
-			return
-		}
-
 		arg := &HelloRequest{}
-
 		contentType := r.Header.Get("Content-Type")
-		switch contentType {
-		case "application/protobuf", "application/x-protobuf":
-			if err := proto.Unmarshal(body, arg); err != nil {
+		if r.Method != http.MethodGet {
+			body, err := ioutil.ReadAll(r.Body)
+			if err != nil {
 				cb(ctx, w, r, nil, nil, err)
 				return
 			}
-		case "application/json":
-			if err := jsonpb.Unmarshal(bytes.NewBuffer(body), arg); err != nil {
+
+			switch contentType {
+			case "application/protobuf", "application/x-protobuf":
+				if err := proto.Unmarshal(body, arg); err != nil {
+					cb(ctx, w, r, nil, nil, err)
+					return
+				}
+			case "application/json":
+				if err := jsonpb.Unmarshal(bytes.NewBuffer(body), arg); err != nil {
+					cb(ctx, w, r, nil, nil, err)
+					return
+				}
+			default:
+				w.WriteHeader(http.StatusUnsupportedMediaType)
+				_, err := fmt.Fprintf(w, "Unsupported Content-Type: %s", contentType)
 				cb(ctx, w, r, nil, nil, err)
 				return
 			}
-		default:
-			w.WriteHeader(http.StatusUnsupportedMediaType)
-			_, err := fmt.Fprintf(w, "Unsupported Content-Type: %s", contentType)
-			cb(ctx, w, r, nil, nil, err)
-			return
 		}
 
 		ret, err := h.srv.SayHello(ctx, arg)
@@ -85,7 +86,16 @@ func (h *GreeterHTTPConverter) SayHello(cb func(ctx context.Context, w http.Resp
 			return
 		}
 
-		switch contentType {
+		accept := r.Header.Get("Accept")
+		if accept == "*/*" {
+			if contentType != "" {
+				accept = contentType
+			} else {
+				accept = "application/json"
+			}
+		}
+
+		switch accept {
 		case "application/protobuf", "application/x-protobuf":
 			buf, err := proto.Marshal(ret)
 			if err != nil {


### PR DESCRIPTION
# Change point
- Allowing to use get method
- Fixed response type was decided by Accept header 
 
I want to use get method. However, this template is not supported. It does not work properly with GET which is not obligatory to set Context-Type because switching processing of request by Context-Type.At the same time, I changed process of switch of response.
It is defined in [here](https://tools.ietf.org/html/rfc7231#page-38).
It is my idea that json returned when Accept is empty.