### PR TITLE
fix: response Content-Type header

### DIFF
--- a/template.go
+++ b/template.go
@@ -118,6 +118,8 @@ func (h *{{ $service.Name }}HTTPConverter) {{ $method.Name }}(cb func(ctx contex
 			}
 		}
 
+		w.Header().Set("Content-Type", accept)
+
 		switch accept {
 		case "application/protobuf", "application/x-protobuf":
 			buf, err := proto.Marshal(ret)
@@ -248,6 +250,8 @@ func (h *{{ $service.Name }}HTTPConverter) {{ $method.Name }}HTTPRule(cb func(ct
 				accept = "application/json"
 			}
 		}
+
+		w.Header().Set("Content-Type", accept)
 
 		switch accept {
 		case "application/protobuf", "application/x-protobuf":

--- a/testdata/httprule/all_pattern.http.go
+++ b/testdata/httprule/all_pattern.http.go
@@ -105,6 +105,8 @@ func (h *AllPatternHTTPConverter) AllPattern(cb func(ctx context.Context, w http
 			}
 		}
 
+		w.Header().Set("Content-Type", accept)
+
 		switch accept {
 		case "application/protobuf", "application/x-protobuf":
 			buf, err := proto.Marshal(ret)
@@ -450,6 +452,8 @@ func (h *AllPatternHTTPConverter) AllPatternHTTPRule(cb func(ctx context.Context
 				accept = "application/json"
 			}
 		}
+
+		w.Header().Set("Content-Type", accept)
 
 		switch accept {
 		case "application/protobuf", "application/x-protobuf":

--- a/testdata/httprule/httprule.http.go
+++ b/testdata/httprule/httprule.http.go
@@ -105,6 +105,8 @@ func (h *MessagingHTTPConverter) GetMessage(cb func(ctx context.Context, w http.
 			}
 		}
 
+		w.Header().Set("Content-Type", accept)
+
 		switch accept {
 		case "application/protobuf", "application/x-protobuf":
 			buf, err := proto.Marshal(ret)
@@ -201,6 +203,8 @@ func (h *MessagingHTTPConverter) GetMessageHTTPRule(cb func(ctx context.Context,
 				accept = "application/json"
 			}
 		}
+
+		w.Header().Set("Content-Type", accept)
 
 		switch accept {
 		case "application/protobuf", "application/x-protobuf":
@@ -303,6 +307,8 @@ func (h *MessagingHTTPConverter) UpdateMessage(cb func(ctx context.Context, w ht
 				accept = "application/json"
 			}
 		}
+
+		w.Header().Set("Content-Type", accept)
 
 		switch accept {
 		case "application/protobuf", "application/x-protobuf":
@@ -413,6 +419,8 @@ func (h *MessagingHTTPConverter) UpdateMessageHTTPRule(cb func(ctx context.Conte
 			}
 		}
 
+		w.Header().Set("Content-Type", accept)
+
 		switch accept {
 		case "application/protobuf", "application/x-protobuf":
 			buf, err := proto.Marshal(ret)
@@ -514,6 +522,8 @@ func (h *MessagingHTTPConverter) SubFieldMessage(cb func(ctx context.Context, w 
 				accept = "application/json"
 			}
 		}
+
+		w.Header().Set("Content-Type", accept)
 
 		switch accept {
 		case "application/protobuf", "application/x-protobuf":
@@ -625,6 +635,8 @@ func (h *MessagingHTTPConverter) SubFieldMessageHTTPRule(cb func(ctx context.Con
 				accept = "application/json"
 			}
 		}
+
+		w.Header().Set("Content-Type", accept)
 
 		switch accept {
 		case "application/protobuf", "application/x-protobuf":

--- a/testdata/routeguide/route_guide.http.go
+++ b/testdata/routeguide/route_guide.http.go
@@ -103,6 +103,8 @@ func (h *RouteGuideHTTPConverter) GetFeature(cb func(ctx context.Context, w http
 			}
 		}
 
+		w.Header().Set("Content-Type", accept)
+
 		switch accept {
 		case "application/protobuf", "application/x-protobuf":
 			buf, err := proto.Marshal(ret)


### PR DESCRIPTION
## tl; dr

- The Content-Type header of the response is always returned as "text/plain".
- Fixed to set this to Accepted Content-Type.