### PR TITLE
Fix `passing outer scope context "ctx"`

### DIFF
--- a/examples/all_pattern.http.go
+++ b/examples/all_pattern.http.go
@@ -111,7 +111,7 @@ func (h *AllPatternHTTPConverter) AllPattern(cb func(ctx context.Context, w http
 		}
 
 		handler := func(c context.Context, req interface{}) (interface{}, error) {
-			return h.srv.AllPattern(ctx, req.(*AllPatternMessage))
+			return h.srv.AllPattern(c, req.(*AllPatternMessage))
 		}
 
 		iret, err := chained(ctx, arg, info, handler)
@@ -476,7 +476,7 @@ func (h *AllPatternHTTPConverter) AllPatternHTTPRule(cb func(ctx context.Context
 		}
 
 		handler := func(c context.Context, req interface{}) (interface{}, error) {
-			return h.srv.AllPattern(ctx, req.(*AllPatternMessage))
+			return h.srv.AllPattern(c, req.(*AllPatternMessage))
 		}
 
 		iret, err := chained(ctx, arg, info, handler)

--- a/examples/greeter.http.go
+++ b/examples/greeter.http.go
@@ -109,7 +109,7 @@ func (h *GreeterHTTPConverter) SayHello(cb func(ctx context.Context, w http.Resp
 		}
 
 		handler := func(c context.Context, req interface{}) (interface{}, error) {
-			return h.srv.SayHello(ctx, req.(*HelloRequest))
+			return h.srv.SayHello(c, req.(*HelloRequest))
 		}
 
 		iret, err := chained(ctx, arg, info, handler)

--- a/examples/httprule.http.go
+++ b/examples/httprule.http.go
@@ -110,7 +110,7 @@ func (h *MessagingHTTPConverter) GetMessage(cb func(ctx context.Context, w http.
 		}
 
 		handler := func(c context.Context, req interface{}) (interface{}, error) {
-			return h.srv.GetMessage(ctx, req.(*GetMessageRequest))
+			return h.srv.GetMessage(c, req.(*GetMessageRequest))
 		}
 
 		iret, err := chained(ctx, arg, info, handler)
@@ -238,7 +238,7 @@ func (h *MessagingHTTPConverter) GetMessageHTTPRule(cb func(ctx context.Context,
 		}
 
 		handler := func(c context.Context, req interface{}) (interface{}, error) {
-			return h.srv.GetMessage(ctx, req.(*GetMessageRequest))
+			return h.srv.GetMessage(c, req.(*GetMessageRequest))
 		}
 
 		iret, err := chained(ctx, arg, info, handler)
@@ -372,7 +372,7 @@ func (h *MessagingHTTPConverter) UpdateMessage(cb func(ctx context.Context, w ht
 		}
 
 		handler := func(c context.Context, req interface{}) (interface{}, error) {
-			return h.srv.UpdateMessage(ctx, req.(*UpdateMessageRequest))
+			return h.srv.UpdateMessage(c, req.(*UpdateMessageRequest))
 		}
 
 		iret, err := chained(ctx, arg, info, handler)
@@ -515,7 +515,7 @@ func (h *MessagingHTTPConverter) UpdateMessageHTTPRule(cb func(ctx context.Conte
 		}
 
 		handler := func(c context.Context, req interface{}) (interface{}, error) {
-			return h.srv.UpdateMessage(ctx, req.(*UpdateMessageRequest))
+			return h.srv.UpdateMessage(c, req.(*UpdateMessageRequest))
 		}
 
 		iret, err := chained(ctx, arg, info, handler)
@@ -649,7 +649,7 @@ func (h *MessagingHTTPConverter) CreateMessage(cb func(ctx context.Context, w ht
 		}
 
 		handler := func(c context.Context, req interface{}) (interface{}, error) {
-			return h.srv.CreateMessage(ctx, req.(*CreateMessageRequest))
+			return h.srv.CreateMessage(c, req.(*CreateMessageRequest))
 		}
 
 		iret, err := chained(ctx, arg, info, handler)
@@ -795,7 +795,7 @@ func (h *MessagingHTTPConverter) CreateMessageHTTPRule(cb func(ctx context.Conte
 		}
 
 		handler := func(c context.Context, req interface{}) (interface{}, error) {
-			return h.srv.CreateMessage(ctx, req.(*CreateMessageRequest))
+			return h.srv.CreateMessage(c, req.(*CreateMessageRequest))
 		}
 
 		iret, err := chained(ctx, arg, info, handler)

--- a/template.go
+++ b/template.go
@@ -124,7 +124,7 @@ func (h *{{ $service.Name }}HTTPConverter) {{ $method.Name }}(cb func(ctx contex
 		}
 
 		handler := func(c context.Context, req interface{}) (interface{}, error) {
-			return h.srv.{{ $method.Name }}(ctx, req.(* {{ $method.Arg }}))
+			return h.srv.{{ $method.Name }}(c, req.(* {{ $method.Arg }}))
 		}
 
 		iret, err := chained(ctx, arg, info, handler)
@@ -287,7 +287,7 @@ func (h *{{ $service.Name }}HTTPConverter) {{ $method.Name }}HTTPRule(cb func(ct
 		}
 
 		handler := func(c context.Context, req interface{}) (interface{}, error) {
-			return h.srv.{{ $method.Name }}(ctx, req.(* {{ $method.Arg }}))
+			return h.srv.{{ $method.Name }}(c, req.(* {{ $method.Arg }}))
 		}
 
 		iret, err := chained(ctx, arg, info, handler)

--- a/testdata/auth/auth.http.go
+++ b/testdata/auth/auth.http.go
@@ -109,7 +109,7 @@ func (h *TestServiceHTTPConverter) UnaryCall(cb func(ctx context.Context, w http
 		}
 
 		handler := func(c context.Context, req interface{}) (interface{}, error) {
-			return h.srv.UnaryCall(ctx, req.(*Request))
+			return h.srv.UnaryCall(c, req.(*Request))
 		}
 
 		iret, err := chained(ctx, arg, info, handler)

--- a/testdata/helloworld/helloworld.http.go
+++ b/testdata/helloworld/helloworld.http.go
@@ -111,7 +111,7 @@ func (h *GreeterHTTPConverter) SayHello(cb func(ctx context.Context, w http.Resp
 		}
 
 		handler := func(c context.Context, req interface{}) (interface{}, error) {
-			return h.srv.SayHello(ctx, req.(*HelloRequest))
+			return h.srv.SayHello(c, req.(*HelloRequest))
 		}
 
 		iret, err := chained(ctx, arg, info, handler)

--- a/testdata/httprule/all_pattern.http.go
+++ b/testdata/httprule/all_pattern.http.go
@@ -111,7 +111,7 @@ func (h *AllPatternHTTPConverter) AllPattern(cb func(ctx context.Context, w http
 		}
 
 		handler := func(c context.Context, req interface{}) (interface{}, error) {
-			return h.srv.AllPattern(ctx, req.(*AllPatternRequest))
+			return h.srv.AllPattern(c, req.(*AllPatternRequest))
 		}
 
 		iret, err := chained(ctx, arg, info, handler)
@@ -476,7 +476,7 @@ func (h *AllPatternHTTPConverter) AllPatternHTTPRule(cb func(ctx context.Context
 		}
 
 		handler := func(c context.Context, req interface{}) (interface{}, error) {
-			return h.srv.AllPattern(ctx, req.(*AllPatternRequest))
+			return h.srv.AllPattern(c, req.(*AllPatternRequest))
 		}
 
 		iret, err := chained(ctx, arg, info, handler)

--- a/testdata/httprule/httprule.http.go
+++ b/testdata/httprule/httprule.http.go
@@ -111,7 +111,7 @@ func (h *MessagingHTTPConverter) GetMessage(cb func(ctx context.Context, w http.
 		}
 
 		handler := func(c context.Context, req interface{}) (interface{}, error) {
-			return h.srv.GetMessage(ctx, req.(*GetMessageRequest))
+			return h.srv.GetMessage(c, req.(*GetMessageRequest))
 		}
 
 		iret, err := chained(ctx, arg, info, handler)
@@ -240,7 +240,7 @@ func (h *MessagingHTTPConverter) GetMessageHTTPRule(cb func(ctx context.Context,
 		}
 
 		handler := func(c context.Context, req interface{}) (interface{}, error) {
-			return h.srv.GetMessage(ctx, req.(*GetMessageRequest))
+			return h.srv.GetMessage(c, req.(*GetMessageRequest))
 		}
 
 		iret, err := chained(ctx, arg, info, handler)
@@ -374,7 +374,7 @@ func (h *MessagingHTTPConverter) UpdateMessage(cb func(ctx context.Context, w ht
 		}
 
 		handler := func(c context.Context, req interface{}) (interface{}, error) {
-			return h.srv.UpdateMessage(ctx, req.(*UpdateMessageRequest))
+			return h.srv.UpdateMessage(c, req.(*UpdateMessageRequest))
 		}
 
 		iret, err := chained(ctx, arg, info, handler)
@@ -515,7 +515,7 @@ func (h *MessagingHTTPConverter) UpdateMessageHTTPRule(cb func(ctx context.Conte
 		}
 
 		handler := func(c context.Context, req interface{}) (interface{}, error) {
-			return h.srv.UpdateMessage(ctx, req.(*UpdateMessageRequest))
+			return h.srv.UpdateMessage(c, req.(*UpdateMessageRequest))
 		}
 
 		iret, err := chained(ctx, arg, info, handler)
@@ -649,7 +649,7 @@ func (h *MessagingHTTPConverter) SubFieldMessage(cb func(ctx context.Context, w 
 		}
 
 		handler := func(c context.Context, req interface{}) (interface{}, error) {
-			return h.srv.SubFieldMessage(ctx, req.(*SubFieldMessageRequest))
+			return h.srv.SubFieldMessage(c, req.(*SubFieldMessageRequest))
 		}
 
 		iret, err := chained(ctx, arg, info, handler)
@@ -792,7 +792,7 @@ func (h *MessagingHTTPConverter) SubFieldMessageHTTPRule(cb func(ctx context.Con
 		}
 
 		handler := func(c context.Context, req interface{}) (interface{}, error) {
-			return h.srv.SubFieldMessage(ctx, req.(*SubFieldMessageRequest))
+			return h.srv.SubFieldMessage(c, req.(*SubFieldMessageRequest))
 		}
 
 		iret, err := chained(ctx, arg, info, handler)

--- a/testdata/routeguide/route_guide.http.go
+++ b/testdata/routeguide/route_guide.http.go
@@ -109,7 +109,7 @@ func (h *RouteGuideHTTPConverter) GetFeature(cb func(ctx context.Context, w http
 		}
 
 		handler := func(c context.Context, req interface{}) (interface{}, error) {
-			return h.srv.GetFeature(ctx, req.(*Point))
+			return h.srv.GetFeature(c, req.(*Point))
 		}
 
 		iret, err := chained(ctx, arg, info, handler)


### PR DESCRIPTION
# tl; dr

- Use ctx in closure and eliminate passing outer scope context "ctx"