### PR TITLE
fix to use ParseMediaType

### DIFF
--- a/examples/all_pattern.http.go
+++ b/examples/all_pattern.http.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"mime"
 	"net/http"
 	"strconv"
 	"strings"
@@ -41,7 +42,7 @@ func (h *AllPatternHTTPConverter) AllPattern(cb func(ctx context.Context, w http
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				p := status.New(codes.Unknown, err.Error()).Proto()
-				switch r.Header.Get("Content-Type") {
+				switch contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type")); contentType {
 				case "application/protobuf", "application/x-protobuf":
 					buf, err := proto.Marshal(p)
 					if err != nil {
@@ -63,7 +64,7 @@ func (h *AllPatternHTTPConverter) AllPattern(cb func(ctx context.Context, w http
 		ctx := r.Context()
 
 		arg := &AllPatternMessage{}
-		contentType := r.Header.Get("Content-Type")
+		contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
 		if r.Method != http.MethodGet {
 			body, err := ioutil.ReadAll(r.Body)
 			if err != nil {
@@ -179,7 +180,7 @@ func (h *AllPatternHTTPConverter) AllPatternHTTPRule(cb func(ctx context.Context
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				p := status.New(codes.Unknown, err.Error()).Proto()
-				switch r.Header.Get("Content-Type") {
+				switch contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type")); contentType {
 				case "application/protobuf", "application/x-protobuf":
 					buf, err := proto.Marshal(p)
 					if err != nil {
@@ -201,7 +202,7 @@ func (h *AllPatternHTTPConverter) AllPatternHTTPRule(cb func(ctx context.Context
 		ctx := r.Context()
 
 		arg := &AllPatternMessage{}
-		contentType := r.Header.Get("Content-Type")
+		contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
 		if r.Method == http.MethodGet {
 			if v := r.URL.Query().Get("double"); v != "" {
 				d, err := strconv.ParseFloat(v, 64)

--- a/examples/greeter.http.go
+++ b/examples/greeter.http.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"mime"
 	"net/http"
 	"strings"
 
@@ -39,7 +40,7 @@ func (h *GreeterHTTPConverter) SayHello(cb func(ctx context.Context, w http.Resp
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				p := status.New(codes.Unknown, err.Error()).Proto()
-				switch r.Header.Get("Content-Type") {
+				switch contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type")); contentType {
 				case "application/protobuf", "application/x-protobuf":
 					buf, err := proto.Marshal(p)
 					if err != nil {
@@ -61,7 +62,7 @@ func (h *GreeterHTTPConverter) SayHello(cb func(ctx context.Context, w http.Resp
 		ctx := r.Context()
 
 		arg := &HelloRequest{}
-		contentType := r.Header.Get("Content-Type")
+		contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
 		if r.Method != http.MethodGet {
 			body, err := ioutil.ReadAll(r.Body)
 			if err != nil {

--- a/examples/httprule.http.go
+++ b/examples/httprule.http.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"mime"
 	"net/http"
 	"reflect"
 	"strings"
@@ -40,7 +41,7 @@ func (h *MessagingHTTPConverter) GetMessage(cb func(ctx context.Context, w http.
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				p := status.New(codes.Unknown, err.Error()).Proto()
-				switch r.Header.Get("Content-Type") {
+				switch contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type")); contentType {
 				case "application/protobuf", "application/x-protobuf":
 					buf, err := proto.Marshal(p)
 					if err != nil {
@@ -62,7 +63,7 @@ func (h *MessagingHTTPConverter) GetMessage(cb func(ctx context.Context, w http.
 		ctx := r.Context()
 
 		arg := &GetMessageRequest{}
-		contentType := r.Header.Get("Content-Type")
+		contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
 		if r.Method != http.MethodGet {
 			body, err := ioutil.ReadAll(r.Body)
 			if err != nil {
@@ -178,7 +179,7 @@ func (h *MessagingHTTPConverter) GetMessageHTTPRule(cb func(ctx context.Context,
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				p := status.New(codes.Unknown, err.Error()).Proto()
-				switch r.Header.Get("Content-Type") {
+				switch contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type")); contentType {
 				case "application/protobuf", "application/x-protobuf":
 					buf, err := proto.Marshal(p)
 					if err != nil {
@@ -200,7 +201,7 @@ func (h *MessagingHTTPConverter) GetMessageHTTPRule(cb func(ctx context.Context,
 		ctx := r.Context()
 
 		arg := &GetMessageRequest{}
-		contentType := r.Header.Get("Content-Type")
+		contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
 		if r.Method == http.MethodGet {
 			if v := r.URL.Query().Get("message"); v != "" {
 				arg.Message = v
@@ -302,7 +303,7 @@ func (h *MessagingHTTPConverter) UpdateMessage(cb func(ctx context.Context, w ht
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				p := status.New(codes.Unknown, err.Error()).Proto()
-				switch r.Header.Get("Content-Type") {
+				switch contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type")); contentType {
 				case "application/protobuf", "application/x-protobuf":
 					buf, err := proto.Marshal(p)
 					if err != nil {
@@ -324,7 +325,7 @@ func (h *MessagingHTTPConverter) UpdateMessage(cb func(ctx context.Context, w ht
 		ctx := r.Context()
 
 		arg := &UpdateMessageRequest{}
-		contentType := r.Header.Get("Content-Type")
+		contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
 		if r.Method != http.MethodGet {
 			body, err := ioutil.ReadAll(r.Body)
 			if err != nil {
@@ -440,7 +441,7 @@ func (h *MessagingHTTPConverter) UpdateMessageHTTPRule(cb func(ctx context.Conte
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				p := status.New(codes.Unknown, err.Error()).Proto()
-				switch r.Header.Get("Content-Type") {
+				switch contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type")); contentType {
 				case "application/protobuf", "application/x-protobuf":
 					buf, err := proto.Marshal(p)
 					if err != nil {
@@ -462,7 +463,7 @@ func (h *MessagingHTTPConverter) UpdateMessageHTTPRule(cb func(ctx context.Conte
 		ctx := r.Context()
 
 		arg := &UpdateMessageRequest{}
-		contentType := r.Header.Get("Content-Type")
+		contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
 		if r.Method != http.MethodGet {
 			body, err := ioutil.ReadAll(r.Body)
 			if err != nil {
@@ -579,7 +580,7 @@ func (h *MessagingHTTPConverter) CreateMessage(cb func(ctx context.Context, w ht
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				p := status.New(codes.Unknown, err.Error()).Proto()
-				switch r.Header.Get("Content-Type") {
+				switch contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type")); contentType {
 				case "application/protobuf", "application/x-protobuf":
 					buf, err := proto.Marshal(p)
 					if err != nil {
@@ -601,7 +602,7 @@ func (h *MessagingHTTPConverter) CreateMessage(cb func(ctx context.Context, w ht
 		ctx := r.Context()
 
 		arg := &CreateMessageRequest{}
-		contentType := r.Header.Get("Content-Type")
+		contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
 		if r.Method != http.MethodGet {
 			body, err := ioutil.ReadAll(r.Body)
 			if err != nil {
@@ -717,7 +718,7 @@ func (h *MessagingHTTPConverter) CreateMessageHTTPRule(cb func(ctx context.Conte
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				p := status.New(codes.Unknown, err.Error()).Proto()
-				switch r.Header.Get("Content-Type") {
+				switch contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type")); contentType {
 				case "application/protobuf", "application/x-protobuf":
 					buf, err := proto.Marshal(p)
 					if err != nil {
@@ -739,7 +740,7 @@ func (h *MessagingHTTPConverter) CreateMessageHTTPRule(cb func(ctx context.Conte
 		ctx := r.Context()
 
 		arg := &CreateMessageRequest{}
-		contentType := r.Header.Get("Content-Type")
+		contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
 		if r.Method != http.MethodGet {
 			body, err := ioutil.ReadAll(r.Body)
 			if err != nil {

--- a/template.go
+++ b/template.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"mime"
 	"net/http"
 	{{ if .IsImportReflect -}}
 	"reflect"
@@ -54,7 +55,7 @@ func (h *{{ $service.Name }}HTTPConverter) {{ $method.Name }}(cb func(ctx contex
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				p := status.New(codes.Unknown, err.Error()).Proto()
-				switch r.Header.Get("Content-Type") {
+				switch contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type")); contentType {
 				case "application/protobuf", "application/x-protobuf":
 					buf, err := proto.Marshal(p)
 					if err != nil {
@@ -76,7 +77,7 @@ func (h *{{ $service.Name }}HTTPConverter) {{ $method.Name }}(cb func(ctx contex
 		ctx := r.Context()
 
 		arg := &{{ $method.Arg }}{}
-		contentType := r.Header.Get("Content-Type")
+		contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
 		if r.Method != http.MethodGet {
 			body, err := ioutil.ReadAll(r.Body)
 			if err != nil {
@@ -197,7 +198,7 @@ func (h *{{ $service.Name }}HTTPConverter) {{ $method.Name }}HTTPRule(cb func(ct
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				p := status.New(codes.Unknown, err.Error()).Proto()
-				switch r.Header.Get("Content-Type") {
+				switch contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type")); contentType {
 				case "application/protobuf", "application/x-protobuf":
 					buf, err := proto.Marshal(p)
 					if err != nil {
@@ -219,7 +220,7 @@ func (h *{{ $service.Name }}HTTPConverter) {{ $method.Name }}HTTPRule(cb func(ct
 		ctx := r.Context()
 
 		arg := &{{ $method.Arg }}{}
-		contentType := r.Header.Get("Content-Type")
+		contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
 		{{ if $method.GetQueryParams -}}
 		if r.Method == http.MethodGet {
 		{{ range $k, $queryParam := $method.GetQueryParams -}}

--- a/testdata/auth/auth.http.go
+++ b/testdata/auth/auth.http.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"mime"
 	"net/http"
 	"strings"
 
@@ -39,7 +40,7 @@ func (h *TestServiceHTTPConverter) UnaryCall(cb func(ctx context.Context, w http
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				p := status.New(codes.Unknown, err.Error()).Proto()
-				switch r.Header.Get("Content-Type") {
+				switch contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type")); contentType {
 				case "application/protobuf", "application/x-protobuf":
 					buf, err := proto.Marshal(p)
 					if err != nil {
@@ -61,7 +62,7 @@ func (h *TestServiceHTTPConverter) UnaryCall(cb func(ctx context.Context, w http
 		ctx := r.Context()
 
 		arg := &Request{}
-		contentType := r.Header.Get("Content-Type")
+		contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
 		if r.Method != http.MethodGet {
 			body, err := ioutil.ReadAll(r.Body)
 			if err != nil {

--- a/testdata/helloworld/helloworld.http.go
+++ b/testdata/helloworld/helloworld.http.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"mime"
 	"net/http"
 	"strings"
 
@@ -41,7 +42,7 @@ func (h *GreeterHTTPConverter) SayHello(cb func(ctx context.Context, w http.Resp
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				p := status.New(codes.Unknown, err.Error()).Proto()
-				switch r.Header.Get("Content-Type") {
+				switch contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type")); contentType {
 				case "application/protobuf", "application/x-protobuf":
 					buf, err := proto.Marshal(p)
 					if err != nil {
@@ -63,7 +64,7 @@ func (h *GreeterHTTPConverter) SayHello(cb func(ctx context.Context, w http.Resp
 		ctx := r.Context()
 
 		arg := &HelloRequest{}
-		contentType := r.Header.Get("Content-Type")
+		contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
 		if r.Method != http.MethodGet {
 			body, err := ioutil.ReadAll(r.Body)
 			if err != nil {

--- a/testdata/httprule/all_pattern.http.go
+++ b/testdata/httprule/all_pattern.http.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"mime"
 	"net/http"
 	"strconv"
 	"strings"
@@ -41,7 +42,7 @@ func (h *AllPatternHTTPConverter) AllPattern(cb func(ctx context.Context, w http
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				p := status.New(codes.Unknown, err.Error()).Proto()
-				switch r.Header.Get("Content-Type") {
+				switch contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type")); contentType {
 				case "application/protobuf", "application/x-protobuf":
 					buf, err := proto.Marshal(p)
 					if err != nil {
@@ -63,7 +64,7 @@ func (h *AllPatternHTTPConverter) AllPattern(cb func(ctx context.Context, w http
 		ctx := r.Context()
 
 		arg := &AllPatternRequest{}
-		contentType := r.Header.Get("Content-Type")
+		contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
 		if r.Method != http.MethodGet {
 			body, err := ioutil.ReadAll(r.Body)
 			if err != nil {
@@ -179,7 +180,7 @@ func (h *AllPatternHTTPConverter) AllPatternHTTPRule(cb func(ctx context.Context
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				p := status.New(codes.Unknown, err.Error()).Proto()
-				switch r.Header.Get("Content-Type") {
+				switch contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type")); contentType {
 				case "application/protobuf", "application/x-protobuf":
 					buf, err := proto.Marshal(p)
 					if err != nil {
@@ -201,7 +202,7 @@ func (h *AllPatternHTTPConverter) AllPatternHTTPRule(cb func(ctx context.Context
 		ctx := r.Context()
 
 		arg := &AllPatternRequest{}
-		contentType := r.Header.Get("Content-Type")
+		contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
 		if r.Method == http.MethodGet {
 			if v := r.URL.Query().Get("double"); v != "" {
 				d, err := strconv.ParseFloat(v, 64)

--- a/testdata/httprule/httprule.http.go
+++ b/testdata/httprule/httprule.http.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"mime"
 	"net/http"
 	"reflect"
 	"strconv"
@@ -41,7 +42,7 @@ func (h *MessagingHTTPConverter) GetMessage(cb func(ctx context.Context, w http.
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				p := status.New(codes.Unknown, err.Error()).Proto()
-				switch r.Header.Get("Content-Type") {
+				switch contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type")); contentType {
 				case "application/protobuf", "application/x-protobuf":
 					buf, err := proto.Marshal(p)
 					if err != nil {
@@ -63,7 +64,7 @@ func (h *MessagingHTTPConverter) GetMessage(cb func(ctx context.Context, w http.
 		ctx := r.Context()
 
 		arg := &GetMessageRequest{}
-		contentType := r.Header.Get("Content-Type")
+		contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
 		if r.Method != http.MethodGet {
 			body, err := ioutil.ReadAll(r.Body)
 			if err != nil {
@@ -179,7 +180,7 @@ func (h *MessagingHTTPConverter) GetMessageHTTPRule(cb func(ctx context.Context,
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				p := status.New(codes.Unknown, err.Error()).Proto()
-				switch r.Header.Get("Content-Type") {
+				switch contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type")); contentType {
 				case "application/protobuf", "application/x-protobuf":
 					buf, err := proto.Marshal(p)
 					if err != nil {
@@ -201,7 +202,7 @@ func (h *MessagingHTTPConverter) GetMessageHTTPRule(cb func(ctx context.Context,
 		ctx := r.Context()
 
 		arg := &GetMessageRequest{}
-		contentType := r.Header.Get("Content-Type")
+		contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
 		if r.Method == http.MethodGet {
 			if v := r.URL.Query().Get("revision"); v != "" {
 				i64, err := strconv.ParseInt(v, 10, 64)
@@ -304,7 +305,7 @@ func (h *MessagingHTTPConverter) UpdateMessage(cb func(ctx context.Context, w ht
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				p := status.New(codes.Unknown, err.Error()).Proto()
-				switch r.Header.Get("Content-Type") {
+				switch contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type")); contentType {
 				case "application/protobuf", "application/x-protobuf":
 					buf, err := proto.Marshal(p)
 					if err != nil {
@@ -326,7 +327,7 @@ func (h *MessagingHTTPConverter) UpdateMessage(cb func(ctx context.Context, w ht
 		ctx := r.Context()
 
 		arg := &UpdateMessageRequest{}
-		contentType := r.Header.Get("Content-Type")
+		contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
 		if r.Method != http.MethodGet {
 			body, err := ioutil.ReadAll(r.Body)
 			if err != nil {
@@ -442,7 +443,7 @@ func (h *MessagingHTTPConverter) UpdateMessageHTTPRule(cb func(ctx context.Conte
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				p := status.New(codes.Unknown, err.Error()).Proto()
-				switch r.Header.Get("Content-Type") {
+				switch contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type")); contentType {
 				case "application/protobuf", "application/x-protobuf":
 					buf, err := proto.Marshal(p)
 					if err != nil {
@@ -464,7 +465,7 @@ func (h *MessagingHTTPConverter) UpdateMessageHTTPRule(cb func(ctx context.Conte
 		ctx := r.Context()
 
 		arg := &UpdateMessageRequest{}
-		contentType := r.Header.Get("Content-Type")
+		contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
 		if r.Method != http.MethodGet {
 			body, err := ioutil.ReadAll(r.Body)
 			if err != nil {
@@ -579,7 +580,7 @@ func (h *MessagingHTTPConverter) SubFieldMessage(cb func(ctx context.Context, w 
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				p := status.New(codes.Unknown, err.Error()).Proto()
-				switch r.Header.Get("Content-Type") {
+				switch contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type")); contentType {
 				case "application/protobuf", "application/x-protobuf":
 					buf, err := proto.Marshal(p)
 					if err != nil {
@@ -601,7 +602,7 @@ func (h *MessagingHTTPConverter) SubFieldMessage(cb func(ctx context.Context, w 
 		ctx := r.Context()
 
 		arg := &SubFieldMessageRequest{}
-		contentType := r.Header.Get("Content-Type")
+		contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
 		if r.Method != http.MethodGet {
 			body, err := ioutil.ReadAll(r.Body)
 			if err != nil {
@@ -717,7 +718,7 @@ func (h *MessagingHTTPConverter) SubFieldMessageHTTPRule(cb func(ctx context.Con
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				p := status.New(codes.Unknown, err.Error()).Proto()
-				switch r.Header.Get("Content-Type") {
+				switch contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type")); contentType {
 				case "application/protobuf", "application/x-protobuf":
 					buf, err := proto.Marshal(p)
 					if err != nil {
@@ -739,7 +740,7 @@ func (h *MessagingHTTPConverter) SubFieldMessageHTTPRule(cb func(ctx context.Con
 		ctx := r.Context()
 
 		arg := &SubFieldMessageRequest{}
-		contentType := r.Header.Get("Content-Type")
+		contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
 		if r.Method != http.MethodGet {
 			body, err := ioutil.ReadAll(r.Body)
 			if err != nil {

--- a/testdata/routeguide/route_guide.http.go
+++ b/testdata/routeguide/route_guide.http.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"mime"
 	"net/http"
 	"strings"
 
@@ -39,7 +40,7 @@ func (h *RouteGuideHTTPConverter) GetFeature(cb func(ctx context.Context, w http
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				p := status.New(codes.Unknown, err.Error()).Proto()
-				switch r.Header.Get("Content-Type") {
+				switch contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type")); contentType {
 				case "application/protobuf", "application/x-protobuf":
 					buf, err := proto.Marshal(p)
 					if err != nil {
@@ -61,7 +62,7 @@ func (h *RouteGuideHTTPConverter) GetFeature(cb func(ctx context.Context, w http
 		ctx := r.Context()
 
 		arg := &Point{}
-		contentType := r.Header.Get("Content-Type")
+		contentType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
 		if r.Method != http.MethodGet {
 			body, err := ioutil.ReadAll(r.Body)
 			if err != nil {


### PR DESCRIPTION
Thanks for the great project!

This change fixes to use `mime.ParseMediaType` instead of accessing "Content-Type" of HTTP headers directly.
In the current implementation, it cannot interpret "application/json; charset=UTF-8" as "application/json" because it doesn't discard optional parameters.